### PR TITLE
Add basic background check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ yarn-error.*
 *.tsbuildinfo
 
 # @end expo-cli
+
+# IDEA
+.idea/

--- a/app/(pages)/(profile)/(verification)/verification.tsx
+++ b/app/(pages)/(profile)/(verification)/verification.tsx
@@ -1,0 +1,239 @@
+import React, { useState } from 'react';
+import {
+    View,
+    Text,
+    TouchableOpacity,
+    Alert,
+    Image,
+    ScrollView,
+    SafeAreaView,
+} from 'react-native';
+import { useNavigation } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
+import { supabase } from '@/clients/supabase';
+import { supabaseAuthClient } from '@/clients/supabase/auth';
+import { DOCUMENT_TYPE_LABELS, DocumentType } from '@/types/backgroundChecks'; // 假设你在 types 目录下定义了 DocumentType 类型
+
+export default function VerificationScreen() {
+    const [selectedOption, setSelectedOption] = useState<DocumentType>('none');
+    const [docImage, setDocImage] = useState<string | null>(null);
+    const [docBackImage, setDocBackImage] = useState<string | null>(null);
+    const [uploading, setUploading] = useState(false);
+    const navigation = useNavigation();
+
+    const insertDocRecord = async ({ userId, docType, docUrl, docBackUrl }: {
+        userId: string;
+        docType: string;
+        docUrl: string;
+        docBackUrl?: string;
+    }) => {
+        try {
+            const { error } = await supabase.from('background_checks').insert([
+                {
+                    user_id: userId,
+                    doc_type: docType,
+                    doc_url: docUrl,
+                    doc_back_url: docBackUrl ?? null,
+                    status: 'pending',
+                    updated_at: new Date().toISOString(),
+                },
+            ]);
+
+            if (error) {
+                Alert.alert('Error', 'Failed to insert');
+                console.error('[Insertion Error]', error);
+                return;
+            }
+            Alert.alert('Success', 'Document record saved!');
+        } catch (error) {
+            console.error('Insert Error:', error);
+            Alert.alert('Error', 'Failed to save document record');
+        }
+    };
+
+    const decode = (base64: string): Uint8Array => {
+        const binaryString = atob(base64);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+            bytes[i] = binaryString.charCodeAt(i);
+        }
+        return bytes;
+    };
+
+    const handleUpload = async () => {
+        if (!docImage) return;
+        setUploading(true);
+        try {
+            const user = await supabaseAuthClient.getUser();
+            if (!user) {
+                Alert.alert('Error', 'User not authenticated');
+                console.error('AUTH ERROR: User not authenticated');
+                return;
+            }
+            const userId = user.id;
+
+            const uploadImage = async (uri: string, label: string): Promise<string> => {
+                const base64 = await FileSystem.readAsStringAsync(uri, {
+                    encoding: FileSystem.EncodingType.Base64,
+                });
+                const filePath = `background-checks/${userId}_${label}_${Date.now()}.jpg`;
+                const { error: uploadError } = await supabase.storage
+                    .from('profile-documents')
+                    .upload(filePath, decode(base64), {
+                        contentType: 'image/jpeg',
+                        cacheControl: '3600',
+                    });
+                if (uploadError) throw uploadError;
+
+                const { data: urlData } = supabase.storage
+                    .from('profile-documents')
+                    .getPublicUrl(filePath);
+                return urlData.publicUrl;
+            };
+
+            const docImageUrl = await uploadImage(docImage, 'front');
+            const docBackImageUrl = docBackImage ? await uploadImage(docBackImage, 'back') : undefined;
+
+            await insertDocRecord({
+                userId,
+                docType: selectedOption,
+                docUrl: docImageUrl,
+                docBackUrl: docBackImageUrl,
+            });
+
+            Alert.alert('Success', 'Documents uploaded and saved!');
+            setSelectedOption('none');
+            setDocImage(null);
+            setDocBackImage(null);
+        } catch (error) {
+            console.error('[Upload Error]', error);
+            const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+            Alert.alert('Upload Failed', errorMessage);
+        } finally {
+            setUploading(false);
+        }
+    };
+
+    const pickImage = async (side: 'front' | 'back', fromCamera: boolean = false) => {
+        try {
+            const permissionMethod = fromCamera
+                ? ImagePicker.requestCameraPermissionsAsync
+                : ImagePicker.requestMediaLibraryPermissionsAsync;
+
+            const { status } = await permissionMethod();
+            if (status !== 'granted') {
+                Alert.alert('Permission denied', fromCamera ? 'Camera' : 'Gallery' + ' permission is required.');
+                return;
+            }
+
+            const result = fromCamera
+                ? await ImagePicker.launchCameraAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.8 })
+                : await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.8 });
+
+            if (!result.canceled && result.assets.length > 0) {
+                const uri = result.assets[0].uri;
+                if (side === 'front') setDocImage(uri);
+                else setDocBackImage(uri);
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : 'Failed to select image';
+            Alert.alert('Error', message);
+        }
+    };
+
+    return (
+        <SafeAreaView className="flex-1 bg-white">
+            <ScrollView className="flex-1 px-4 py-6">
+                <Text className="text-2xl font-bold mb-2 text-center">Verify Your Identity</Text>
+                <Text className="text-base text-gray-600 text-center mb-6">
+                    Choose a document type below to start verifying your identity.
+                </Text>
+
+                {selectedOption === 'none' && (
+                    <View className="space-y-4">
+                        {(['license', 'passport'] as DocumentType[]).map((type) => (
+                            <TouchableOpacity
+                                key={type}
+                                onPress={() => setSelectedOption(type)}
+                                className="p-4 bg-gray-100 rounded-xl flex-row justify-between items-center"
+                            >
+                                <Text className="text-base font-medium capitalize">{DOCUMENT_TYPE_LABELS[type as keyof typeof DOCUMENT_TYPE_LABELS]}</Text>
+                                <Ionicons name="chevron-forward" size={20} color="#888" />
+                            </TouchableOpacity>
+                        ))}
+                    </View>
+                )}
+
+                {selectedOption !== 'none' && (
+                    <View className="mt-6">
+                        <Text className="text-lg font-semibold mb-4">
+                            {selectedOption === 'license'
+                                ? 'Upload your Driver License (Front and Back)'
+                                : 'Upload your Passport'}
+                        </Text>
+
+                        <View className="space-y-3">
+                            <Text className="text-sm font-medium">Front Side</Text>
+                            <View className="flex-row gap-4">
+                                <TouchableOpacity onPress={() => pickImage('front', false)} className="flex-1 bg-gray-100 p-4 rounded-lg items-center">
+                                    <Ionicons name="images-outline" size={28} color="#555" />
+                                    <Text className="text-xs text-gray-700 mt-1">Gallery</Text>
+                                </TouchableOpacity>
+                                <TouchableOpacity onPress={() => pickImage('front', true)} className="flex-1 bg-gray-100 p-4 rounded-lg items-center">
+                                    <Ionicons name="camera-outline" size={28} color="#555" />
+                                    <Text className="text-xs text-gray-700 mt-1">Take Photo</Text>
+                                </TouchableOpacity>
+                            </View>
+                            {docImage && (
+                                <View className="mt-4 items-center">
+                                    <Image source={{ uri: docImage }} className="w-60 h-36 rounded-lg" resizeMode="cover" />
+                                    <Text className="text-sm text-gray-600 mt-1">Front preview</Text>
+                                </View>
+                            )}
+
+                            {selectedOption === 'license' && (
+                                <>
+                                    <Text className="text-sm font-medium mt-4">Back Side</Text>
+                                    <View className="flex-row gap-4">
+                                        <TouchableOpacity onPress={() => pickImage('back', false)} className="flex-1 bg-gray-100 p-4 rounded-lg items-center">
+                                            <Ionicons name="images-outline" size={28} color="#555" />
+                                            <Text className="text-xs text-gray-700 mt-1">Gallery</Text>
+                                        </TouchableOpacity>
+                                        <TouchableOpacity onPress={() => pickImage('back', true)} className="flex-1 bg-gray-100 p-4 rounded-lg items-center">
+                                            <Ionicons name="camera-outline" size={28} color="#555" />
+                                            <Text className="text-xs text-gray-700 mt-1">Take Photo</Text>
+                                        </TouchableOpacity>
+                                    </View>
+                                    {docBackImage && (
+                                        <View className="mt-4 items-center">
+                                            <Image source={{ uri: docBackImage }} className="w-60 h-36 rounded-lg" resizeMode="cover" />
+                                            <Text className="text-sm text-gray-600 mt-1">Back preview</Text>
+                                        </View>
+                                    )}
+                                </>
+                            )}
+                        </View>
+
+                        <View className="space-y-4 mt-6">
+                            <TouchableOpacity onPress={handleUpload} disabled={uploading} className="bg-blue-600 px-6 py-3 rounded-xl">
+                                <Text className="text-white text-base font-medium text-center">
+                                    {uploading ? 'Uploading...' : 'Upload Now'}
+                                </Text>
+                            </TouchableOpacity>
+
+                            <TouchableOpacity onPress={() => setSelectedOption('none')} className="mt-4">
+                                <Text className="text-blue-500 text-center">Back to Document Options</Text>
+                            </TouchableOpacity>
+                        </View>
+                    </View>
+                )}
+
+                <TouchableOpacity onPress={() => navigation.goBack()} className="mt-10">
+                    <Text className="text-blue-500 text-center">Back to Profile</Text>
+                </TouchableOpacity>
+            </ScrollView>
+        </SafeAreaView>
+    );
+}

--- a/app/(pages)/(profile)/editProfile.tsx
+++ b/app/(pages)/(profile)/editProfile.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, {useEffect, useState} from 'react';
 import {
   View,
   Text,
@@ -13,6 +13,8 @@ import { Ionicons } from '@expo/vector-icons';
 import { useProfileModel } from '@/models/profileModel';
 import { supabaseAuthClient } from '@/clients/supabase/auth';
 import { supabaseDBClient } from '@/clients/supabase/database';
+import { BACKGROUND_CHECK_STATUSES } from '@/types/backgroundChecks';
+import { supabase } from "@/clients/supabase";
 
 export default function EditProfile() {
   const router = useRouter();
@@ -24,6 +26,53 @@ export default function EditProfile() {
     last_name: myProfile?.last_name || '',
     location: myProfile?.location,
   });
+
+  const checkVerificationStatus = async () => {
+    try {
+      const user = await supabaseAuthClient.getUser();
+      if (!user) {
+        Alert.alert('Error', 'User not authenticated');
+        console.error('AUTH ERROR: User not authenticated');
+        return;
+      }
+
+      const { data, error } = await supabase
+          .from('background_checks')
+          .select('status')
+          .eq('user_id', user.id)
+          .order('updated_at', { ascending: false })
+          .limit(1);
+
+      if (error) {
+        Alert.alert('Error', 'Failed to fetch verification status');
+        console.error('[Fetch Error]', error);
+        return;
+      }
+
+      const latestStatus = data?.[0]?.status;
+      if (latestStatus) {
+        const newStatus = latestStatus
+
+        // 同步更新 profiles 表中的 verification_status
+        await supabase
+            .from('profiles')
+            .update({ verification_status: newStatus, updated_at: new Date().toISOString() })
+            .eq('user_id', user.id);
+
+        setMyProfile({ ...myProfile!, verification_status: newStatus });
+      }
+    } catch (error: unknown) {
+      const errorMessage =
+          error instanceof Error ? error.message : 'Failed to check verification status';
+      Alert.alert('Error', errorMessage);
+      console.error('[Check Verification]', error);
+    }
+  };
+
+  useEffect(() => {
+    checkVerificationStatus().then();
+  }, []);
+
 
   const updateProfile = async () => {
     try {
@@ -134,16 +183,45 @@ export default function EditProfile() {
         {/* Verifications */}
         <View className="mb-6">
           <Text className="font-semibold mb-2">Verifications</Text>
-          <TouchableOpacity className="flex-row items-center justify-between p-4 bg-gray-50 rounded-lg">
+          <TouchableOpacity
+              onPress={() => router.push('/verification')}
+              disabled={
+                  myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.VERIFIED ||
+                  myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.PENDING
+              }
+              className={`flex-row items-center justify-between p-4 rounded-lg
+          ${myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.VERIFIED ? 'bg-green-100'
+                  : myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.PENDING ? 'bg-blue-50'
+                      : 'bg-gray-50'}`}
+          >
             <View className="flex-row items-center">
               <Ionicons
-                name="shield-checkmark-outline"
-                size={24}
-                color="#666"
+                  name="shield-checkmark-outline"
+                  size={24}
+                  color={
+                    myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.VERIFIED
+                        ? '#22c55e'
+                        : myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.PENDING
+                            ? '#3b82f6'
+                            : '#666'
+                  }
               />
-              <Text className="ml-2">Get Verified</Text>
+              <Text className="ml-2">
+                {myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.VERIFIED
+                    ? 'Verified ✅'
+                    : myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.PENDING
+                        ? 'Pending...'
+                        : 'Get Verified'}
+              </Text>
             </View>
-            <Ionicons name="chevron-forward" size={24} color="#666" />
+
+            {myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.NOT_VERIFIED && (
+                <Ionicons name="chevron-forward" size={24} color="#666" />
+            )}
+
+            {myProfile?.verification_status === BACKGROUND_CHECK_STATUSES.PENDING && (
+                <Ionicons name="time-outline" size={24} color="#3b82f6" />
+            )}
           </TouchableOpacity>
         </View>
 

--- a/clients/supabase/database.ts
+++ b/clients/supabase/database.ts
@@ -5,6 +5,7 @@ import { User } from '@supabase/auth-js';
 import { Address } from '@/types/address';
 import { WorkPreference } from '@/types/workPreferences';
 import { Task } from '@/types/task';
+import { BackgroundCheckStatus } from "@/types/backgroundChecks";
 
 export const supabaseDBClient = {
   getUserById: async (userId: string): Promise<User> => {
@@ -106,6 +107,34 @@ export const supabaseDBClient = {
       })
       .select()
       .single();
+    if (error) {
+      throw new Error(error.message);
+    }
+  },
+
+  getVerificationStatus: async (userId: string): Promise<BackgroundCheckStatus> => {
+    const { data, error } = await supabase
+        .from('profiles')
+        .select('verification_status')
+        .eq('user_id', userId)
+        .single();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+    return data.verification_status as BackgroundCheckStatus;
+  },
+
+  updateVerificationStatus: async (userId: string, status: BackgroundCheckStatus) => {
+    const { error } = await supabase
+        .from('profiles')
+        .update({
+          verification_status: status,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('user_id', userId)
+        .single();
+
     if (error) {
       throw new Error(error.message);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,14 +5,16 @@
     "jsx": "react-native",
     "esModuleInterop": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
     "**/*.ts",
     "**/*.tsx",
+    "nativewind-env.d.ts",
     ".expo/types/**/*.ts",
-    "expo-env.d.ts",
-    "nativewind-env.d.ts"
+    "expo-env.d.ts"
   ]
 }

--- a/types/backgroundChecks.ts
+++ b/types/backgroundChecks.ts
@@ -1,0 +1,17 @@
+export const BACKGROUND_CHECK_STATUSES = {
+    NOT_VERIFIED: 'not_verified',
+    PENDING: 'pending',
+    VERIFIED: 'verified',
+    REJECTED: 'rejected',
+} as const;
+
+export type BackgroundCheckStatus = (typeof BACKGROUND_CHECK_STATUSES)[keyof typeof BACKGROUND_CHECK_STATUSES];
+
+export const DOCUMENT_TYPE_LABELS = {
+    license: 'Australian Driver License',
+    passport: 'Passport',
+    medicare: 'Medicare Card',
+    student_id: 'Student ID',
+} as const;
+
+export type DocumentType = keyof typeof DOCUMENT_TYPE_LABELS | 'none';

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -1,3 +1,5 @@
+import {BackgroundCheckStatus} from "@/types/backgroundChecks";
+
 export enum Role {
   LaundryPartner = 'Laundry Partner',
   Supervisor = 'Supervisor',
@@ -18,6 +20,7 @@ export type Profile = {
   bio?: string;
   location?: string;
   pricing?: string;
+  verification_status?: BackgroundCheckStatus;
 };
 
 export type TimeSlot = {


### PR DESCRIPTION
Feature Overview:
Users can now tap "Get Verified" to navigate to the Verification screen

They can choose to verify with either:
- Australian Driver License (requires both front and back images)
- Passport

Supports both camera capture and photo library upload
Upload Behavior:
After uploading, the documents are:
- Stored in Supabase Storage under profile-documents/background-checks
- Recorded in the background_checks table with status set to 'pending'
- The user's profiles.verification_status is automatically updated to pending

Status Handling:
- While status is 'pending', the "Get Verified" button becomes disabled
- Once the uploaded document is manually reviewed and marked as approved in the database, the verification status becomes 'verified'
- If rejected, the status will reset to 'not_verified', allowing re-submission